### PR TITLE
Update manifest.json: Xóa version number của package voluptuous

### DIFF
--- a/custom_components/nestup_evn/manifest.json
+++ b/custom_components/nestup_evn/manifest.json
@@ -11,7 +11,7 @@
     "name": "EVN Data Fetcher",
     "requirements": [
         "python_dateutil",
-        "voluptuous==0.13.1"
+        "voluptuous"
     ],
     "version": "2.4.1"
 }


### PR DESCRIPTION
Update manifest.json: Xóa version number của package voluptuous

# Description

Phiên bản Home Assistant Core 2024.8 đã update voluptuous lên bản 0.15.2, nhưng add-on đang để version cố định voluptuous==0.13.1 dẫn đến lỗi trong quá trình setup. PR này xóa version number của package voluptuous để tránh xảy ra lỗi (theo mình hiểu thì nếu không chỉ định version number cho voluptuous thì sẽ tự load phiên bản hiện tại trên hass)

https://github.com/home-assistant/core/pull/120631

![hass_nestup_env_issue_2](https://github.com/user-attachments/assets/43eec0c7-5278-48f0-a1e8-4bb5c18d3502)
![hass_nestup_env_issue](https://github.com/user-attachments/assets/e423045b-85e0-474f-9b6d-a52995d6043b)

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test thủ công ở môi trường local

- [ ] Black
- [ ] Flake8
- [ ] Isort

**Test Configuration**:
* OS version: Home Assistant OS
* HA version: Home Assistant Core 2024.8
* HA platform: 
* Hardware: Generic x86

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
