### PR TITLE
Fix combined entry with date range

### DIFF
--- a/custom_components/nestup_evn/nestup_evn.py
+++ b/custom_components/nestup_evn/nestup_evn.py
@@ -522,12 +522,12 @@ class EVNAPI:
 
         resp_json = resp_json["data"]["sanluong_tungngay"]
 
-        from_date = parser.parse(resp_json[0]["ngayFull"], dayfirst=True)
-        to_date = parser.parse(
-            resp_json[(-2 if len(resp_json) > 2 else 0)]["ngayFull"], dayfirst=True
+        from_date = strip_date_range(resp_json[0]["ngayFull"])
+        to_date = strip_date_range(
+            resp_json[(-2 if len(resp_json) > 2 else 0)]["ngayFull"]
         )
-        previous_date = parser.parse(
-            resp_json[(-3 if len(resp_json) > 3 else 0)]["ngayFull"], dayfirst=True
+        previous_date = strip_date_range(
+            resp_json[(-3 if len(resp_json) > 3 else 0)]["ngayFull"]
         )
 
         econ_total_new = round(
@@ -1188,6 +1188,13 @@ def format_loadshedding(raw_value: str) -> str:
     
     except Exception as e:
         return STATUS_LOADSHEDDING
+
+def strip_date_range(date_str):
+    if "đến" in date_str:
+        strip_date_range = date_str.split("đến")[1].strip()
+    else:
+        strip_date_range = date_str.strip()
+    return parser.parse(strip_date_range, dayfirst=True)
 
 async def fetch_with_retries(
     url, headers, params, max_retries=3, session=None, allow_empty=False, api_name="API"

--- a/custom_components/nestup_evn/nestup_evn.py
+++ b/custom_components/nestup_evn/nestup_evn.py
@@ -1191,10 +1191,10 @@ def format_loadshedding(raw_value: str) -> str:
 
 def strip_date_range(date_str):
     if "đến" in date_str:
-        strip_date_range = date_str.split("đến")[1].strip()
+        stripped_date = date_str.split("đến")[1].strip()
     else:
-        strip_date_range = date_str.strip()
-    return parser.parse(strip_date_range, dayfirst=True)
+        stripped_date = date_str.strip()
+    return parser.parse(stripped_date, dayfirst=True)
 
 async def fetch_with_retries(
     url, headers, params, max_retries=3, session=None, allow_empty=False, api_name="API"


### PR DESCRIPTION
# Description

Fix combined entry for dates that are skipped by EVN. e.g. "ngayFull": "06/01/2025 đến 07/01/2025". Taking "to" date since entries for previous day exists, but has 0/no measurement...

e.g.
```
      {
        "ngay": "06/01",
        "ngayFull": "06/01/2025",
        "TD": 0,
        "BT": 0,
        "CD": 0,
        "Tong": 0,
        "sanluong_TD": "0.00",
        "sanluong_BT": "0.00",
        "sanluong_CD": "0.00",
        "sanluong_tong": "!",
        "hsn": 1,
        "p_giao_bt": "0.00",
        "p_giao_td": "0.00",
        "p_giao_cd": "0.00",
        "tong_p_giao": "0.00",
        "tong_q_giao": "0.00",
        "thoidiemdo": "06/01/2025",
        "isChotHoaDon": 0
      },
      {
        "ngay": "06/01 đến 07/01",
        "ngayFull": "06/01/2025 đến 07/01/2025", ### Combined record due missing data from previous day
        "TD": 0,
        "BT": 17.89,
        "CD": 0,
        "Tong": 17.89,
        "sanluong_TD": "0.00",
        "sanluong_BT": "17.89",
        "sanluong_CD": "0.00",
        "sanluong_tong": "17.89",
        "hsn": 1,
        "p_giao_bt": "23,619.93",
        "p_giao_td": "0.00",
        "p_giao_cd": "0.00",
        "tong_p_giao": "23,619.93",
        "tong_q_giao": "0.00",
        "thoidiemdo": "Từ 06/01/2025 đến 07/01/2025",
        "isChotHoaDon": 0
      },
```

> 2025-01-20 17:47:52.172 ERROR (MainThread) [custom_components.nestup_evn.sensor] Unexpected error fetching nestup_evn-XXX data
> Traceback (most recent call last):
>   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 379, in _async_refresh
>     self.data = await self._async_update_data()
>                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 280, in _async_update_data
>     return await self.update_method()
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/config/custom_components/nestup_evn/sensor.py", line 123, in _async_update
>     await self.update()
>   File "/config/custom_components/nestup_evn/sensor.py", line 82, in update
>     self._data = await self._api.request_update(
>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>         self._area_name, self._username, self._password, self._customer_id, self._monthly_start
>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     )
>     ^
>   File "/config/custom_components/nestup_evn/nestup_evn.py", line 122, in request_update
>     fetch_data = await self.request_update_evnhcmc(
>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>         username, password, customer_id, from_date, to_date
>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     )
>     ^
>   File "/config/custom_components/nestup_evn/nestup_evn.py", line 529, in request_update_evnhcmc
>     previous_date = parser.parse(
>         resp_json[(-3 if len(resp_json) > 3 else 0)]["ngayFull"], dayfirst=True
>     )
>   File "/usr/local/lib/python3.13/site-packages/dateutil/parser/_parser.py", line 1368, in parse
>     return DEFAULTPARSER.parse(timestr, **kwargs)
>            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
>   File "/usr/local/lib/python3.13/site-packages/dateutil/parser/_parser.py", line 643, in parse
>     raise ParserError("Unknown string format: %s", timestr)
> dateutil.parser._parser.ParserError: Unknown string format: 17/01/2025 đến 18/01/2025
> 2025-01-20 17:47:52.187 ERROR (MainThread) [homeassistant.helpers.entity_platform] nestup_evn raises exception ConfigEntryNotReady in forwarded platform sensor; Instead raise ConfigEntryNotReady before calling async_forward_entry_setups

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Black
- [ ] Flake8
- [ ] Isort

**Test Configuration**:
* OS version:
* HA version:
* HA platform:
* Hardware:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
